### PR TITLE
Fix ever-increasing Postgres AWS RDS storage issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,12 @@ Background reading: [Postgres CDC Source connector documentation](https://docs.c
 9. Expand the "Show advanced configurations" dropdown and enter the following:
    - JSON output decimal format: `NUMERIC`
    - Plugin name: `pgoutput`
-   - Tables included: `public.transaction`
+   - Tables included: `public.transaction,public.debezium_heartbeat`
    - Decimal handling mode: `string`
+   - Heartbeat interval (ms): `240000`
+   - Heartbeat action query: `UPDATE debezium_heartbeat set last_heartbeat_ts = now();` 
+
+     ([further reading on why the heartbeat is needed](https://github.com/bb-mvp/kafka-pipeline/issues/32))
 10. Click on "Continue"
 11. Click on "Continue" on the "Connector sizing" page
 12. Click on "Continue" on the "Review and launch page"
@@ -159,18 +163,6 @@ This is very straightforward:
    Also, if you then kick off another GitHub Actions workflow run to add more bank transactions to your
    AWS database, if you go to the "Messages" tab of your Kakfa topic and keep the page open, you will see
    the bank transactions appear in Kakfa in realtime.
-
-#### Delete your AWS database to avoid paying for consuming too much storage
-
-Under certain conditions the AWS database is consuming storage very quickly after connecting the database to Kafka via Postgres CDC. This can exhaust AWS's free monthly 20GB limit and lead to credit card charges.
-
-We have a [GitHub issue for this](https://github.com/bb-mvp/kafka-pipeline/issues/30), and all contributors are very
-welcome to try to solve it.
-
-Until this issue is solved the recommended course of action is to delete the AWS database after successfully verifying you have the CDC connection between Kafka and the database working.  It looks like it takes several hours for the 20GB to be
-consumed, but it's best to delete (or at least pause) the AWS database as soon as you are finished working with it.
-(Pausing it is great, but has the important caveat that it will automatically be restarted again after 7 days, which is a
-little dangerous compared to deleting it).
 
 
 

--- a/dbchangelog.xml
+++ b/dbchangelog.xml
@@ -1,5 +1,7 @@
 <?xml version="1.1" encoding="UTF-8" standalone="no"?>
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+                                                                                                                                                                                                                                                             http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd
+                                                                                                                                                                                                                                                             http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
     <property name="now" value="now()" dbms="postgresql" />
     <changeSet author="cfagaras" id="1">
         <createTable tableName="transaction">
@@ -20,5 +22,16 @@
             <column name="source_account" type="VARCHAR" />
             <column name="destination_account" type="VARCHAR" />
         </createTable>
+    </changeSet>
+    <changeSet author="johnboyes" id="2">
+        <comment>As per https://github.com/bb-mvp/kafka-pipeline/issues/32</comment>
+        <createTable tableName="debezium_heartbeat">
+            <column name="last_heartbeat_ts" type="datetime" defaultValue="${now}">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="debezium_heartbeat_pkey" />
+            </column>
+        </createTable>
+        <insert tableName="debezium_heartbeat">
+            <column name="last_heartbeat_ts" value="${now}" />
+        </insert>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
The [Postgres WAL (Write-Ahead Log)][1] was growing permanently after starting Debezium's CDC (Change Data Capture) on Confluent Cloud's Kafka. The reason was that our AWS RDS database is mostly idle, but under the hood AWS RDS writes to its own system tables every 5 minutes (see the [tip in Debezium's documentation][2] for more info).  This was causing the WAL to keep growing as Debezium was not being invoked and therefore the database was not reconciling the WAL.

The fix in this commit is to add a heartbeat table to the database and to configure Confluent Cloud / Kakfa / Debezium to update this table via the heartbeat, while also configuring the update to be emitted via Debezium. That is to say we include the heartbeat table in the list of tables that Debezium connects to (ensuring that the heartbeat events are emitted and therefore that the database reconciles the WAL, recapturing the disk space).

You can verify that this fix is working properly by running the SQL query below against your AWS database and then running it again after, say, 30 minutes.  You will see that the `replicationslotlag` is much the same both times (in testing it has appeared no higher than 192MB, which is fine), instead of being significantly larger the second time.

`SELECT slot_name, pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(),restart_lsn)) AS replicationSlotLag, active FROM pg_replication_slots ;`

[1]: https://www.postgresql.org/docs/current/wal-intro.html
[2]: https://debezium.io/documentation/reference/1.0/connectors/postgresql.html#wal-disk-space